### PR TITLE
meta: exclude custom CODEOWNERS

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -36,7 +36,7 @@ for version in versions:
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(
     source_location='build/src', versions=['v1beta1'])
-s.copy(templates, excludes=[])
+s.copy(templates, excludes=[".github/CODEOWNERS"])
 
 node.postprocess_gapic_library()
 


### PR DESCRIPTION
CODEOWNERS should be excluded because it differs from what we are able to autogenerate.