### PR TITLE
chore: limit samples code ownership to source files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,5 +11,5 @@
 .github/auto-approve.yml                 @googleapis/github-automation
 
 # @Irataxy will own samples
-samples/ @irataxy
+samples/**/*.js @irataxy
 


### PR DESCRIPTION
This unblocks #104 which is requiring review from the samples owner even though samples haven't been touched.